### PR TITLE
Differentiate certificates comes from different relations

### DIFF
--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -36,7 +36,7 @@ class DummyCertificateTransferProviderCharm(CharmBase):
         certificate = "my certificate"
         ca = "my CA certificate"
         chain = ["certificate 1", "certificate 2"]
-        self.certificate_transfer.set_certificate(certificate=certificate, ca=ca, chain=chain)
+        self.certificate_transfer.set_certificate(certificate=certificate, ca=ca, chain=chain, relation_id=event.relation.id)
 
 
 if __name__ == "__main__":
@@ -101,7 +101,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["jsonschema"]
 
@@ -232,6 +232,9 @@ class CertificateTransferProvides(Object):
         Returns:
             None
         """
+        if relation_id is None:
+            raise RuntimeError("relation_id should be provided.")
+
         relation = self.model.get_relation(
             relation_name=self.relationship_name,
             relation_id=relation_id,
@@ -254,6 +257,9 @@ class CertificateTransferProvides(Object):
         Returns:
             None
         """
+        if relation_id is None:
+            raise RuntimeError("relation_id should be provided.")
+
         relation = self.model.get_relation(
             relation_name=self.relationship_name,
             relation_id=relation_id,

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -258,7 +258,8 @@ class CertificateTransferProvides(Object):
             None
         """
         if relation_id is None:
-            raise RuntimeError("relation_id should be provided.")
+            logger.warning("relation_id should be provided.")
+            return
 
         relation = self.model.get_relation(
             relation_name=self.relationship_name,

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -88,7 +88,7 @@ juju relate <certificate_transfer provider charm> <certificate_transfer requirer
 
 import json
 import logging
-from typing import List, Optional
+from typing import List
 
 from jsonschema import exceptions, validate  # type: ignore[import]
 from ops.charm import CharmBase, CharmEvents, RelationChangedEvent
@@ -224,7 +224,7 @@ class CertificateTransferProvides(Object):
         certificate: str,
         ca: str,
         chain: List[str],
-        relation_id: Optional[int] = None,
+        relation_id: int,
     ) -> None:
         """Add certificates to relation data.
 
@@ -237,9 +237,6 @@ class CertificateTransferProvides(Object):
         Returns:
             None
         """
-        if relation_id is None:
-            raise RuntimeError("relation_id should be provided.")
-
         relation = self.model.get_relation(
             relation_name=self.relationship_name,
             relation_id=relation_id,
@@ -253,7 +250,7 @@ class CertificateTransferProvides(Object):
         relation.data[self.model.unit]["ca"] = ca
         relation.data[self.model.unit]["chain"] = json.dumps(chain)
 
-    def remove_certificate(self, relation_id: Optional[int] = None) -> None:
+    def remove_certificate(self, relation_id: int) -> None:
         """Remove a given certificate from relation data.
 
         Args:
@@ -262,10 +259,6 @@ class CertificateTransferProvides(Object):
         Returns:
             None
         """
-        if relation_id is None:
-            logger.warning("relation_id should be provided.")
-            return
-
         relation = self.model.get_relation(
             relation_name=self.relationship_name,
             relation_id=relation_id,

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -70,6 +70,7 @@ class DummyCertificateTransferRequirerCharm(CharmBase):
         print(event.certificate)
         print(event.ca)
         print(event.chain)
+        print(event.relation_id)
 
 
 if __name__ == "__main__":
@@ -161,11 +162,13 @@ class CertificateAvailableEvent(EventBase):
         certificate: str,
         ca: str,
         chain: List[str],
+        relation_id: int,
     ):
         super().__init__(handle)
         self.certificate = certificate
         self.ca = ca
         self.chain = chain
+        self.relation_id = relation_id
 
     def snapshot(self) -> dict:
         """Return snapshot."""
@@ -173,6 +176,7 @@ class CertificateAvailableEvent(EventBase):
             "certificate": self.certificate,
             "ca": self.ca,
             "chain": self.chain,
+            "relation_id": self.relation_id,
         }
 
     def restore(self, snapshot: dict):
@@ -180,6 +184,7 @@ class CertificateAvailableEvent(EventBase):
         self.certificate = snapshot["certificate"]
         self.ca = snapshot["ca"]
         self.chain = snapshot["chain"]
+        self.relation_id = snapshot["relation_id"]
 
 
 def _load_relation_data(raw_relation_data: dict) -> dict:
@@ -350,4 +355,5 @@ class CertificateTransferRequires(Object):
             certificate=remote_unit_relation_data.get("certificate"),
             ca=remote_unit_relation_data.get("ca"),
             chain=remote_unit_relation_data.get("chain"),
+            relation_id=remote_unit_relation_data.get("relation_id"),
         )

--- a/tests/unit/charms/certificate_transfer_interface/v0/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/dummy_provider_charm/src/charm.py
@@ -21,7 +21,9 @@ class DummyCertificateTransferProviderCharm(CharmBase):
         certificate = "my certificate"
         ca = "my CA certificate"
         chain = ["certificate 1", "certificate 2"]
-        self.certificate_transfer.set_certificate(certificate=certificate, ca=ca, chain=chain)
+        self.certificate_transfer.set_certificate(
+            certificate=certificate, ca=ca, chain=chain, relation_id=event.relation.id
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
@@ -22,6 +22,7 @@ class DummyCertificateTransferRequirerCharm(CharmBase):
         print(event.certificate)
         print(event.ca)
         print(event.chain)
+        print(event.relation_id)
 
 
 if __name__ == "__main__":

--- a/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
@@ -19,10 +19,7 @@ class DummyCertificateTransferRequirerCharm(CharmBase):
         )
 
     def _on_certificate_available(self, event: CertificateAvailableEvent):
-        print(event.certificate)
-        print(event.ca)
-        print(event.chain)
-        print(event.relation_id)
+        pass
 
 
 if __name__ == "__main__":

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
@@ -70,15 +70,21 @@ class TestCertificateTransferProvides(unittest.TestCase):
                 certificate=certificate, ca=ca, chain=chain, relation_id=wrong_relation_id
             )
 
-    def test_given_no_certificate_transfer_relation_a_dummy_relation_id_is_provided_when_set_certificate_then_key_error_is_raised(  # noqa: E501
+    def test_given_no_certificate_transfer_relation_a_wrong_relation_id_is_provided_when_set_certificate_then_key_error_is_raised(  # noqa: E501
         self,
     ):
         certificate = "whatever cert"
         ca = "whatever ca"
         chain = ["whatever cert 1", "whatever cert 2"]
+        wrong_relation_id = 0  # We select a dummy relation number.
+        with self.assertRaises(KeyError):  # A relation which has wrong_relation_id does not exist.
+            self.harness.get_relation_data(
+                app_or_unit="certificate-transfer-interface-provider/0",
+                relation_id=wrong_relation_id,
+            )
         with self.assertRaises(KeyError):
             self.harness.charm.certificate_transfer.set_certificate(
-                certificate=certificate, ca=ca, chain=chain, relation_id=0
+                certificate=certificate, ca=ca, chain=chain, relation_id=wrong_relation_id
             )
 
     def test_given_certificate_transfer_relation_exists_when_remove_certificate_then_certificate_removed_from_relation_data(  # noqa: E501

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
@@ -50,26 +50,18 @@ class TestCertificateTransferProvides(unittest.TestCase):
         self.assertEqual(relation_data["ca"], ca)
         self.assertEqual(relation_data["chain"], json.dumps(chain))
 
-    def test_given_relation_id_not_provided_and_certificate_transfer_relation_exists_when_set_certificate_then_certificate_added_to_relation_data(  # noqa: E501
+    def test_given_wrong_relation_id_and_certificate_transfer_relation_exists_when_set_certificate_then_raises_key_error(  # noqa: E501
         self,
     ):
         relation_id = self.create_certificate_transfer_relation()
-
+        relation_id = relation_id + 5
         certificate = "whatever cert"
         ca = "whatever ca"
         chain = ["whatever cert 1", "whatever cert 2"]
-
-        self.harness.charm.certificate_transfer.set_certificate(
-            certificate=certificate, ca=ca, chain=chain
-        )
-
-        relation_data = self.harness.get_relation_data(
-            app_or_unit="certificate-transfer-interface-provider/0",
-            relation_id=relation_id,
-        )
-        self.assertEqual(relation_data["certificate"], certificate)
-        self.assertEqual(relation_data["ca"], ca)
-        self.assertEqual(relation_data["chain"], json.dumps(chain))
+        with self.assertRaises(KeyError):
+            self.harness.charm.certificate_transfer.set_certificate(
+                certificate=certificate, ca=ca, chain=chain, relation_id=relation_id
+            )
 
     def test_given_no_certificate_transfer_relation_when_set_certificate_then_runtime_error_is_raised(  # noqa: E501
         self,
@@ -77,11 +69,11 @@ class TestCertificateTransferProvides(unittest.TestCase):
         certificate = "whatever cert"
         ca = "whatever ca"
         chain = ["whatever cert 1", "whatever cert 2"]
-
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as error:
             self.harness.charm.certificate_transfer.set_certificate(
                 certificate=certificate, ca=ca, chain=chain
             )
+        self.assertEqual(str(error.exception), "relation_id should be provided.")
 
     def test_given_certificate_transfer_relation_exists_when_remove_certificate_then_certificate_removed_from_relation_data(  # noqa: E501
         self,
@@ -129,7 +121,7 @@ class TestCertificateTransferProvides(unittest.TestCase):
         )
         assert "certificate" not in relation_data
 
-    def test_given_certificate_transfer_relation_exists_and_id_not_provided_when_remove_certificate_then_certificate_removed_from_relation_data(  # noqa: E501
+    def test_given_certificate_transfer_relation_exists_and_id_not_provided_when_remove_certificate_then_raises_run_time_error(  # noqa: E501
         self,
     ):
         relation_id = self.create_certificate_transfer_relation()
@@ -143,31 +135,37 @@ class TestCertificateTransferProvides(unittest.TestCase):
             key_values=relation_data,
             app_or_unit="certificate-transfer-interface-provider/0",
         )
-
-        self.harness.charm.certificate_transfer.remove_certificate()
-
-        relation_data = self.harness.get_relation_data(
-            app_or_unit="certificate-transfer-interface-provider/0",
-            relation_id=relation_id,
-        )
-        assert "certificate" not in relation_data
-        assert "ca" not in relation_data
-        assert "chain" not in relation_data
-
-    def test_given_certificate_transfer_relation_doesnt_exist_when_remove_then_log_is_emitted(
-        self,
-    ):
-        with self.assertLogs(BASE_LIB_DIR, level="WARNING") as log:
+        with self.assertRaises(RuntimeError) as error:
             self.harness.charm.certificate_transfer.remove_certificate()
 
-        assert "Can't remove certificate - Non-existent relation 'certificates'" in log.output[0]
+        self.assertEqual(str(error.exception), "relation_id should be provided.")
+
+    def test_given_certificate_transfer_relation_exists_and_wrong_relation_id_provided_when_remove_certificate_then_data_exists_in_relation(  # noqa: E501
+        self,
+    ):
+        relation_id = self.create_certificate_transfer_relation()
+        relation_data = {
+            "certificate": "whatever cert",
+            "ca": "whatever ca",
+            "chain": json.dumps(["cert 1", "cert 2"]),
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            key_values=relation_data,
+            app_or_unit="certificate-transfer-interface-provider/0",
+        )
+        relation_id = int(relation_id) + 2
+        self.harness.charm.certificate_transfer.remove_certificate(relation_id=relation_id)
+        assert "certificate" in relation_data
+        assert "ca" in relation_data
+        assert "chain" in relation_data
 
     def test_given_no_data_in_certificate_transfer_relation_when_remove_certificate_then_log_is_emitted(  # noqa: E501
         self,
     ):
-        self.create_certificate_transfer_relation()
+        relation_id = self.create_certificate_transfer_relation()
 
         with self.assertLogs(BASE_LIB_DIR, level="WARNING") as log:
-            self.harness.charm.certificate_transfer.remove_certificate()
+            self.harness.charm.certificate_transfer.remove_certificate(relation_id=relation_id)
 
         assert "Can't remove certificate - No certificate in relation data" in log.output[0]

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
@@ -63,17 +63,16 @@ class TestCertificateTransferProvides(unittest.TestCase):
                 certificate=certificate, ca=ca, chain=chain, relation_id=relation_id
             )
 
-    def test_given_no_certificate_transfer_relation_when_set_certificate_then_runtime_error_is_raised(  # noqa: E501
+    def test_given_no_certificate_transfer_relation_a_dummy_relation_id_is_provided_when_set_certificate_then_key_error_is_raised(  # noqa: E501
         self,
     ):
         certificate = "whatever cert"
         ca = "whatever ca"
         chain = ["whatever cert 1", "whatever cert 2"]
-        with self.assertRaises(RuntimeError) as error:
+        with self.assertRaises(KeyError):
             self.harness.charm.certificate_transfer.set_certificate(
-                certificate=certificate, ca=ca, chain=chain
+                certificate=certificate, ca=ca, chain=chain, relation_id=0
             )
-        self.assertEqual(str(error.exception), "relation_id should be provided.")
 
     def test_given_certificate_transfer_relation_exists_when_remove_certificate_then_certificate_removed_from_relation_data(  # noqa: E501
         self,
@@ -120,25 +119,6 @@ class TestCertificateTransferProvides(unittest.TestCase):
             relation_id=relation_id,
         )
         assert "certificate" not in relation_data
-
-    def test_given_certificate_transfer_relation_exists_and_id_not_provided_when_remove_certificate_then_log_is_emitted(  # noqa: E501
-        self,
-    ):
-        relation_id = self.create_certificate_transfer_relation()
-        relation_data = {
-            "certificate": "whatever cert",
-            "ca": "whatever ca",
-            "chain": json.dumps(["cert 1", "cert 2"]),
-        }
-        self.harness.update_relation_data(
-            relation_id=relation_id,
-            key_values=relation_data,
-            app_or_unit="certificate-transfer-interface-provider/0",
-        )
-        with self.assertLogs(BASE_LIB_DIR, level="WARNING") as log:
-            self.harness.charm.certificate_transfer.remove_certificate()
-
-        assert "relation_id should be provided" in log.output[0]
 
     def test_given_certificate_transfer_relation_exists_and_wrong_relation_id_provided_when_remove_certificate_then_data_exists_in_relation(  # noqa: E501
         self,

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
@@ -121,7 +121,7 @@ class TestCertificateTransferProvides(unittest.TestCase):
         )
         assert "certificate" not in relation_data
 
-    def test_given_certificate_transfer_relation_exists_and_id_not_provided_when_remove_certificate_then_raises_run_time_error(  # noqa: E501
+    def test_given_certificate_transfer_relation_exists_and_id_not_provided_when_remove_certificate_then_log_is_emitted(  # noqa: E501
         self,
     ):
         relation_id = self.create_certificate_transfer_relation()
@@ -135,10 +135,10 @@ class TestCertificateTransferProvides(unittest.TestCase):
             key_values=relation_data,
             app_or_unit="certificate-transfer-interface-provider/0",
         )
-        with self.assertRaises(RuntimeError) as error:
+        with self.assertLogs(BASE_LIB_DIR, level="WARNING") as log:
             self.harness.charm.certificate_transfer.remove_certificate()
 
-        self.assertEqual(str(error.exception), "relation_id should be provided.")
+        assert "relation_id should be provided" in log.output[0]
 
     def test_given_certificate_transfer_relation_exists_and_wrong_relation_id_provided_when_remove_certificate_then_data_exists_in_relation(  # noqa: E501
         self,

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_provides.py
@@ -54,13 +54,20 @@ class TestCertificateTransferProvides(unittest.TestCase):
         self,
     ):
         relation_id = self.create_certificate_transfer_relation()
-        relation_id = relation_id + 5
+        wrong_relation_id = (
+            relation_id + 2
+        )  # We choose a relation id which is different than we created.
+        with self.assertRaises(KeyError):  # A relation which has wrong_relation_id does not exist.
+            self.harness.get_relation_data(
+                app_or_unit="certificate-transfer-interface-provider/0",
+                relation_id=wrong_relation_id,
+            )
         certificate = "whatever cert"
         ca = "whatever ca"
         chain = ["whatever cert 1", "whatever cert 2"]
         with self.assertRaises(KeyError):
             self.harness.charm.certificate_transfer.set_certificate(
-                certificate=certificate, ca=ca, chain=chain, relation_id=relation_id
+                certificate=certificate, ca=ca, chain=chain, relation_id=wrong_relation_id
             )
 
     def test_given_no_certificate_transfer_relation_a_dummy_relation_id_is_provided_when_set_certificate_then_key_error_is_raised(  # noqa: E501
@@ -134,8 +141,8 @@ class TestCertificateTransferProvides(unittest.TestCase):
             key_values=relation_data,
             app_or_unit="certificate-transfer-interface-provider/0",
         )
-        relation_id = int(relation_id) + 2
-        self.harness.charm.certificate_transfer.remove_certificate(relation_id=relation_id)
+        wrong_relation_id = int(relation_id) + 2
+        self.harness.charm.certificate_transfer.remove_certificate(relation_id=wrong_relation_id)
         assert "certificate" in relation_data
         assert "ca" in relation_data
         assert "chain" in relation_data

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires.py
@@ -46,6 +46,7 @@ class TestCertificateTransferRequires(unittest.TestCase):
             "certificate": certificate,
             "ca": ca,
             "chain": chain_string,
+            "relation_id": str(relation_id),
         }
         self.harness.update_relation_data(
             relation_id=relation_id, app_or_unit=remote_unit_name, key_values=key_values
@@ -56,6 +57,7 @@ class TestCertificateTransferRequires(unittest.TestCase):
         assert certificate_available_event.certificate == certificate
         assert certificate_available_event.ca == ca
         assert certificate_available_event.chain == chain
+        assert certificate_available_event.relation_id == relation_id
 
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")  # noqa: E501
     def test_given_only_certificate_in_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(  # noqa: E501
@@ -67,6 +69,7 @@ class TestCertificateTransferRequires(unittest.TestCase):
         certificate = "whatever certificate"
         key_values = {
             "certificate": certificate,
+            "relation_id": str(relation_id),
         }
         self.harness.update_relation_data(
             relation_id=relation_id, app_or_unit=remote_unit_name, key_values=key_values
@@ -77,6 +80,7 @@ class TestCertificateTransferRequires(unittest.TestCase):
         assert certificate_available_event.certificate == certificate
         assert certificate_available_event.ca is None
         assert certificate_available_event.chain is None
+        assert certificate_available_event.relation_id == relation_id
 
     def test_given_none_of_the_expected_keys_in_relation_data_when_relation_changed_then_warning_log_is_emitted(  # noqa: E501
         self,


### PR DESCRIPTION
# Description

This PR adds relations ids to set_certificate and remove_certificate operations for Certificate Transfer Provider.
It aims to fix https://github.com/canonical/certificate-transfer-interface/issues/6

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
