### PR TITLE
Add custom relation broken event

### DIFF
--- a/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
@@ -6,6 +6,7 @@ from ops.main import main
 
 from lib.charms.certificate_transfer_interface.v0.certificate_transfer import (
     CertificateAvailableEvent,
+    CertificateRemovedEvent,
     CertificateTransferRequires,
 )
 
@@ -17,8 +18,14 @@ class DummyCertificateTransferRequirerCharm(CharmBase):
         self.framework.observe(
             self.certificate_transfer.on.certificate_available, self._on_certificate_available
         )
+        self.framework.observe(
+            self.certificate_transfer.on.certificate_removed, self._on_certificate_removed
+        )
 
     def _on_certificate_available(self, event: CertificateAvailableEvent):
+        pass
+
+    def _on_certificate_removed(self, event: CertificateRemovedEvent):
         pass
 
 

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires.py
@@ -113,3 +113,14 @@ class TestCertificateTransferRequires(unittest.TestCase):
             )
 
         assert "No remote unit in relation" in log.output[0]
+
+    @patch(f"{BASE_CHARM_DIR}._on_certificate_removed")
+    def test_given_certificate_in_relation_data_when_relation_broken_then_certificate_removed_event_is_emitted(  # noqa: E501
+        self, patch_on_certificate_removed
+    ):
+        remote_unit_name = "certificate-transfer-provider/0"
+        relation_id = self.create_certificate_transfer_relation()
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name=remote_unit_name)
+        self.harness.remove_relation(relation_id)
+
+        patch_on_certificate_removed.assert_called()


### PR DESCRIPTION
# Description

This PR adds a custom `certificate_removed` event, emitted when the relation is broken.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
