### PR TITLE
add relation_id to certificate removed and fix certificate_available

### DIFF
--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -375,7 +375,7 @@ class CertificateTransferRequires(Object):
             certificate=remote_unit_relation_data.get("certificate"),
             ca=remote_unit_relation_data.get("ca"),
             chain=remote_unit_relation_data.get("chain"),
-            relation_id=remote_unit_relation_data.get("relation_id"),
+            relation_id=event.relation.id,
         )
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -109,7 +109,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 PYDEPS = ["jsonschema"]
 


### PR DESCRIPTION
# Description

Fixes #5.

The `certificate_removed` event should also provide a `relation_id`, to allow a Requirer to delete the specific certificate coming from that relation.

I'm not entirely sure why the `relation_id` is currently taken from relation data instead of using the one from the event directly, as this (to my understanding) produces a couple issues:
* `relation_id` is set by the Provider; if there are two Providers they might set the same `relation_id`, and the Requirer wouldn't be able to differentiate;
* for relation broken, to figure out which certificate to delete, the Requirer needs to access the relation data of the broken relation (is that something we should do?)

The `relation_id` in the Requirer should come from the `RelationChangedEvent`/`RelationBrokenEvent` observed on the Requirer side.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
