### PR TITLE
chore: use build-packages in charm

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,9 @@ bases:
 
 parts:
   charm:
-    charm-binary-python-packages:
-      - cryptography
-      - jsonschema
+    build-packages:
+      - libffi-dev
+      - libssl-dev
+      - rustc
+      - cargo
+      - pkg-config


### PR DESCRIPTION
# Description

Replace `charm-binary-python-packages` with `build-packages` to ensure more reliable builds where python packages will only come from requirements file.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
