### PR TITLE
chore: centralise metadata in charmcraft.yaml

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Upload charm to Charmhub
-        uses: canonical/charming-actions/upload-charm@2.4.0
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,3 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: certificate-transfer-interface
+
+summary: Placeholder charm
+
+description: Placeholder charm.
+
 type: charm
 bases:
   - build-on:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,0 @@
-name: certificate-transfer-interface
-
-display-name: Certificate Transfer Interface
-
-summary: Placeholder charm
-
-description: Placeholder charm.


### PR DESCRIPTION
# Description

All charm metadata can now be centralised in 1 metadata file: `charmcraft.yaml`. This PR makes the necessary changes to use only this file.

## Reference
- https://juju.is/docs/sdk/charmcraft-yaml

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
