### PR TITLE
style: Format using ruff

### DIFF
--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -112,7 +112,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 PYDEPS = ["jsonschema"]
 

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -96,7 +96,6 @@ juju relate <certificate_transfer provider charm> <certificate_transfer requirer
 
 """
 
-
 import json
 import logging
 from typing import List, Mapping

--- a/tox.ini
+++ b/tox.ini
@@ -30,12 +30,14 @@ pass_env =
 description = Apply coding style standards to code
 commands =
     ruff check --fix {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
     codespell {tox_root}
     ruff check {[vars]all_path}
+    ruff format --check {[vars]all_path}
 
 [testenv:static]
 description = Run static type checks


### PR DESCRIPTION
Currently, ruff is only configured to check the files for linting errors. This adds ruff formatting to tox checks.

Review notes:

Only tox.ini contains functional changes, the rest are the result of running tox -e format.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
