### PR TITLE
test: un-skip tests for non-existent relations

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -34,9 +34,11 @@ decorator==5.1.1
     # via
     #   ipdb
     #   ipython
+durationpy==0.7
+    # via kubernetes
 executing==2.1.0
     # via stack-data
-google-auth==2.34.0
+google-auth==2.35.0
     # via kubernetes
 hvac==2.3.0
     # via juju
@@ -60,7 +62,7 @@ juju==3.5.2.0
     # via
     #   -r test-requirements.in
     #   pytest-operator
-kubernetes==30.1.0
+kubernetes==31.0.0
     # via juju
 macaroonbakery==1.3.4
     # via juju
@@ -80,7 +82,7 @@ ops==2.16.1
     # via
     #   -c requirements.txt
     #   ops-scenario
-ops-scenario==7.0.2
+ops-scenario==7.0.5
     # via -r test-requirements.in
 packaging==24.1
     # via
@@ -96,7 +98,7 @@ pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.28.1
+protobuf==5.28.2
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
@@ -124,7 +126,7 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.380
+pyright==1.1.381
     # via -r test-requirements.in
 pytest==8.3.3
     # via
@@ -166,7 +168,7 @@ rpds-py==0.18.1
     #   referencing
 rsa==4.9
     # via google-auth
-ruff==0.6.5
+ruff==0.6.6
     # via -r test-requirements.in
 six==1.16.0
     # via

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
@@ -81,7 +81,6 @@ class TestCertificateTransferProvidesV1:
             "At least 1 matching relation ID not found with the relation name 'certificate_transfer'",  # noqa: E501
         ) in logs
 
-    @pytest.mark.skip(reason="https://github.com/canonical/ops-scenario/issues/193")
     def test_given_unrelated_relation_when_add_certificates_then_error_is_logged(
         self, caplog: pytest.LogCaptureFixture
     ):
@@ -245,7 +244,6 @@ the databags except using the public methods in the provider library and use ver
             "At least 1 matching relation ID not found with the relation name 'certificate_transfer'",  # noqa: E501
         ) in logs
 
-    @pytest.mark.skip(reason="https://github.com/canonical/ops-scenario/issues/193")
     def test_given_unrelated_relation_when_remove_certificate_then_error_is_logged(
         self, caplog: pytest.LogCaptureFixture
     ):


### PR DESCRIPTION
# Description

As the issue mentioned below has been fixed in `ops-senario`, we un-skip the tests that were initially skipped beause of it.

## Reference
- https://github.com/canonical/ops-scenario/issues/193

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
