### PR TITLE
feat: Allow differentiating V0 and V1 programmatically

### DIFF
--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -101,6 +101,7 @@ import logging
 from typing import List, Mapping
 
 from jsonschema import exceptions, validate  # type: ignore[import-untyped]
+from ops import Relation
 from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
 from ops.framework import EventBase, EventSource, Handle, Object
 
@@ -391,3 +392,13 @@ class CertificateTransferRequires(Object):
             None
         """
         self.on.certificate_removed.emit(relation_id=event.relation.id)
+
+    def is_ready(self, relation: Relation) -> bool:
+        """Checks if the relation is ready by checking that it has valid relation data."""
+        relation_data = _load_relation_data(relation.data[relation.app])
+        if not self._relation_data_is_valid(relation_data):
+            logger.warning(
+                f"Provider relation data did not pass JSON Schema validation: "
+            )
+            return False
+        return True

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -113,7 +113,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["jsonschema"]
 

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -394,11 +394,9 @@ class CertificateTransferRequires(Object):
         self.on.certificate_removed.emit(relation_id=event.relation.id)
 
     def is_ready(self, relation: Relation) -> bool:
-        """Checks if the relation is ready by checking that it has valid relation data."""
+        """Check if the relation is ready by checking that it has valid relation data."""
         relation_data = _load_relation_data(relation.data[relation.app])
         if not self._relation_data_is_valid(relation_data):
-            logger.warning(
-                f"Provider relation data did not pass JSON Schema validation: "
-            )
+            logger.warning("Provider relation data did not pass JSON Schema validation: ")
             return False
         return True

--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -115,7 +115,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 
@@ -212,7 +212,7 @@ class CertificateTransferProvides(Object):
     """Certificate Transfer provider class to be instantiated by charms sending certificates."""
 
     def __init__(self, charm: CharmBase, relationship_name: str):
-        super().__init__(charm, relationship_name)
+        super().__init__(charm, relationship_name + "_v1")
         self.charm = charm
         self.relationship_name = relationship_name
 
@@ -376,7 +376,7 @@ class CertificateTransferRequires(Object):
             charm: Charm object
             relationship_name: Juju relation name
         """
-        super().__init__(charm, relationship_name)
+        super().__init__(charm, relationship_name + "_v1")
         self.relationship_name = relationship_name
         self.charm = charm
         self.framework.observe(

--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -428,6 +428,15 @@ class CertificateTransferRequires(Object):
             result = result.union(data)
         return result
 
+    def is_ready(self, relation: Relation) -> bool:
+        """Check if the relation is ready by checking that it has valid relation data."""
+        databag = relation.data[relation.app]
+        try:
+            ProviderApplicationData().load(databag)
+            return True
+        except DataValidationError:
+            return False
+
     def _get_relation_data(self, relation: Relation) -> Set[str]:
         """Get the given relation data."""
         databag = relation.data[relation.app]

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires_v0.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires_v0.py
@@ -124,3 +124,39 @@ class TestCertificateTransferRequiresV0(unittest.TestCase):
         self.harness.remove_relation(relation_id)
 
         patch_on_certificate_removed.assert_called()
+
+    def test_given_invalid_relation_data_when_is_ready_then_false_is_returned(self):
+        remote_unit_name = "certificate-transfer-provider/0"
+        relation_id = self.create_certificate_transfer_relation()
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name=remote_unit_name)
+        key_values = {
+            "banana": "whatever banana content",
+            "pizza": "whatever pizza content",
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=remote_unit_name, key_values=key_values
+        )
+        relation = self.harness.model.get_relation(
+            relation_name="certificates", relation_id=relation_id
+        )
+        assert not self.harness.charm.certificate_transfer.is_ready(relation)
+
+    def test_given_valid_relation_data_when_is_ready_then_true_is_returned(self):
+        relation_id = self.create_certificate_transfer_relation()
+        relation = self.harness.model.get_relation(
+            relation_name="certificates", relation_id=relation_id
+        )
+        self.harness.add_relation_unit(
+            relation_id=relation_id, remote_unit_name="certificate-transfer-provider/0"
+        )
+        certificate = "whatever certificate"
+        key_values = {
+            "certificate": certificate,
+            "relation_id": str(relation_id),
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit="certificate-transfer-provider",
+            key_values=key_values,
+        )
+        assert self.harness.charm.certificate_transfer.is_ready(relation)

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires_v0.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires_v0.py
@@ -139,6 +139,7 @@ class TestCertificateTransferRequiresV0(unittest.TestCase):
         relation = self.harness.model.get_relation(
             relation_name="certificates", relation_id=relation_id
         )
+        assert relation
         assert not self.harness.charm.certificate_transfer.is_ready(relation)
 
     def test_given_valid_relation_data_when_is_ready_then_true_is_returned(self):
@@ -159,4 +160,5 @@ class TestCertificateTransferRequiresV0(unittest.TestCase):
             app_or_unit="certificate-transfer-provider",
             key_values=key_values,
         )
+        assert relation
         assert self.harness.charm.certificate_transfer.is_ready(relation)

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
@@ -21,6 +21,9 @@ class DummyCertificateTransferRequirerCharm(CharmBase):
         self.framework.observe(
             self.on.get_all_certificates_action, self._on_get_all_certificates_action
         )
+        self.framework.observe(
+            self.on.is_ready_action, self._on_is_ready_action
+        )
 
     def _on_get_all_certificates_action(self, event: ActionEvent):
         relation_id = event.params.get("relation-id", None)
@@ -28,6 +31,14 @@ class DummyCertificateTransferRequirerCharm(CharmBase):
             relation_id=int(relation_id) if relation_id else None
         )
         event.set_results({"certificates": certificates})
+
+    def _on_is_ready_action(self, event: ActionEvent):
+        relation_id = event.params.get("relation-id", None)
+        relation = self.model.get_relation(
+            relation_name="certificate_transfer", relation_id=int(relation_id)
+        )
+        is_ready = self.certificate_transfer.is_ready(relation)
+        event.set_results({"is-ready": is_ready})
 
 
 class TestCertificateTransferRequiresV1:
@@ -41,6 +52,11 @@ class TestCertificateTransferRequiresV1:
             },
             actions={
                 "get-all-certificates": {
+                    "params": {
+                        "relation-id": {"type": "string"},
+                    },
+                },
+                "is-ready": {
                     "params": {
                         "relation-id": {"type": "string"},
                     },
@@ -143,3 +159,33 @@ the databags except using the public methods in the provider library and use ver
             "certificate_transfer",
             error_msg,
         ) in logs
+
+    def test_given_invalid_relation_data_when_is_ready_then_false_is_returned(self):
+        relation = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"certificates": "some string"},
+        )
+        state_in = scenario.State(leader=True, relations=[relation])
+
+        self.ctx.run(
+            self.ctx.on.action("is-ready", params={"relation-id": str(relation.id)}),
+            state_in,
+        )
+
+        assert not self.ctx.action_results["is-ready"]
+
+    def test_given_valid_relation_data_when_is_ready_then_true_is_returned(self):
+        relation = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"certificates": json.dumps(["cert1"])},
+        )
+        state_in = scenario.State(leader=True, relations=[relation])
+
+        self.ctx.run(
+            self.ctx.on.action("is-ready", params={"relation-id": str(relation.id)}),
+            state_in,
+        )
+
+        assert self.ctx.action_results["is-ready"]

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
@@ -21,9 +21,7 @@ class DummyCertificateTransferRequirerCharm(CharmBase):
         self.framework.observe(
             self.on.get_all_certificates_action, self._on_get_all_certificates_action
         )
-        self.framework.observe(
-            self.on.is_ready_action, self._on_is_ready_action
-        )
+        self.framework.observe(self.on.is_ready_action, self._on_is_ready_action)
 
     def _on_get_all_certificates_action(self, event: ActionEvent):
         relation_id = event.params.get("relation-id", None)
@@ -37,6 +35,7 @@ class DummyCertificateTransferRequirerCharm(CharmBase):
         relation = self.model.get_relation(
             relation_name="certificate_transfer", relation_id=int(relation_id)
         )
+        assert relation
         is_ready = self.certificate_transfer.is_ready(relation)
         event.set_results({"is-ready": is_ready})
 
@@ -172,7 +171,7 @@ the databags except using the public methods in the provider library and use ver
             self.ctx.on.action("is-ready", params={"relation-id": str(relation.id)}),
             state_in,
         )
-
+        assert self.ctx.action_results
         assert not self.ctx.action_results["is-ready"]
 
     def test_given_valid_relation_data_when_is_ready_then_true_is_returned(self):
@@ -187,5 +186,5 @@ the databags except using the public methods in the provider library and use ver
             self.ctx.on.action("is-ready", params={"relation-id": str(relation.id)}),
             state_in,
         )
-
+        assert self.ctx.action_results
         assert self.ctx.action_results["is-ready"]


### PR DESCRIPTION
# Description

Some requirers like Traefik need to support both V0 and V1, no to have two different relations for different implementations of the same interface we improve the library so the requirer can check if it is connecting to a provider that implements V0 or V1:
- Adds the V1 postfix to the Object identifier in V1 of the lib so the objects for both V0 and V1 can be created for the same relation name with no conflicts.
- Adds is_ready() functions to the require that allows the requirer to validate the relation data of the provide, if it passes the checks for V0 then the provider is implementing V0 if it passes the checks for V1 then the provider is implementing V1, then the requirer can run different code for different providers.


This will be used to address the comments in [this](https://github.com/canonical/traefik-k8s-operator/pull/407) PR in Traefik.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
