### PR TITLE
build: Enable pyright to check if type hints are missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src/**.py"]
-
+reportMissingParameterType = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,6 +4,8 @@
 
 """Placeholder charm."""
 
+from typing import Any
+
 from ops.charm import CharmBase
 from ops.main import main
 
@@ -11,7 +13,7 @@ from ops.main import main
 class PlaceholderCharm(CharmBase):
     """Placeholder charm."""
 
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
 
 

--- a/tests/unit/charms/certificate_transfer_interface/v0/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/dummy_provider_charm/src/charm.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from typing import Any
+
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
@@ -10,7 +12,7 @@ from lib.charms.certificate_transfer_interface.v0.certificate_transfer import (
 
 
 class DummyCertificateTransferProviderCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificate_transfer = CertificateTransferProvides(self, "certificates")
         self.framework.observe(

--- a/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from typing import Any
+
 from ops.charm import CharmBase
 from ops.main import main
 
@@ -12,7 +14,7 @@ from lib.charms.certificate_transfer_interface.v0.certificate_transfer import (
 
 
 class DummyCertificateTransferRequirerCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificate_transfer = CertificateTransferRequires(self, "certificates")
         self.framework.observe(

--- a/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires_v0.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/test_certificate_transfer_requires_v0.py
@@ -3,7 +3,7 @@
 
 import json
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from ops import testing
 
@@ -33,7 +33,7 @@ class TestCertificateTransferRequiresV0(unittest.TestCase):
 
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_certificates_in_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(
-        self, patch_certificate_available
+        self, mock_certificate_available: MagicMock
     ):
         remote_unit_name = "certificate-transfer-provider/0"
         relation_id = self.create_certificate_transfer_relation()
@@ -52,7 +52,7 @@ class TestCertificateTransferRequiresV0(unittest.TestCase):
             relation_id=relation_id, app_or_unit=remote_unit_name, key_values=key_values
         )
 
-        args, _ = patch_certificate_available.call_args
+        args, _ = mock_certificate_available.call_args
         certificate_available_event = args[0]
         assert certificate_available_event.certificate == certificate
         assert certificate_available_event.ca == ca
@@ -61,7 +61,7 @@ class TestCertificateTransferRequiresV0(unittest.TestCase):
 
     @patch(f"{BASE_CHARM_DIR}._on_certificate_available")
     def test_given_only_certificate_in_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(
-        self, patch_certificate_available
+        self, mock_certificate_available: MagicMock
     ):
         remote_unit_name = "certificate-transfer-provider/0"
         relation_id = self.create_certificate_transfer_relation()
@@ -75,7 +75,7 @@ class TestCertificateTransferRequiresV0(unittest.TestCase):
             relation_id=relation_id, app_or_unit=remote_unit_name, key_values=key_values
         )
 
-        args, _ = patch_certificate_available.call_args
+        args, _ = mock_certificate_available.call_args
         certificate_available_event = args[0]
         assert certificate_available_event.certificate == certificate
         assert certificate_available_event.ca is None
@@ -116,14 +116,15 @@ class TestCertificateTransferRequiresV0(unittest.TestCase):
 
     @patch(f"{BASE_CHARM_DIR}._on_certificate_removed")
     def test_given_certificate_in_relation_data_when_relation_broken_then_certificate_removed_event_is_emitted(
-        self, patch_on_certificate_removed
+        self,
+        mock_on_certificate_removed: MagicMock,
     ):
         remote_unit_name = "certificate-transfer-provider/0"
         relation_id = self.create_certificate_transfer_relation()
         self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name=remote_unit_name)
         self.harness.remove_relation(relation_id)
 
-        patch_on_certificate_removed.assert_called()
+        mock_on_certificate_removed.assert_called()
 
     def test_given_invalid_relation_data_when_is_ready_then_false_is_returned(self):
         remote_unit_name = "certificate-transfer-provider/0"

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import json
+from typing import Any
 
 import pytest
 import scenario
@@ -13,7 +14,7 @@ from lib.charms.certificate_transfer_interface.v1.certificate_transfer import (
 
 
 class DummyCertificateTransferProviderCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificate_transfer = CertificateTransferProvides(self, "certificate_transfer")
         self.framework.observe(self.on.add_certificates_action, self._on_add_certificates_action)
@@ -125,7 +126,7 @@ the databags except using the public methods in the provider library and use ver
         ],
     )
     def test_given_broken_relation_databag_when_set_certificate_then_error_is_logged(
-        self, caplog, databag_value, error_msg
+        self, caplog: pytest.LogCaptureFixture, databag_value: str, error_msg: str
     ):
         relation = scenario.Relation(
             endpoint="certificate_transfer",

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import json
+from typing import Any
 
 import pytest
 import scenario
@@ -15,7 +16,7 @@ from lib.charms.certificate_transfer_interface.v1.certificate_transfer import (
 
 
 class DummyCertificateTransferRequirerCharm(CharmBase):
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self.certificate_transfer = CertificateTransferRequires(self, "certificate_transfer")
         self.framework.observe(
@@ -81,7 +82,7 @@ class TestCertificateTransferRequiresV1:
         assert self.ctx.emitted_events[1].relation_id == relation.id
 
     def test_given_none_of_the_expected_keys_in_relation_data_when_relation_changed_then_certificate_available_event_emitted_with_empty_cert(
-        self, caplog
+        self, caplog: pytest.LogCaptureFixture
     ):
         relation = scenario.Relation(
             endpoint="certificate_transfer",
@@ -141,7 +142,7 @@ the databags except using the public methods in the provider library and use ver
         ],
     )
     def test_given_broken_relation_databag_when_set_certificate_then_error_is_logged(
-        self, caplog, databag_value, error_msg
+        self, caplog: pytest.LogCaptureFixture, databag_value: str, error_msg: str
     ):
         relation = scenario.Relation(
             endpoint="certificate_transfer",


### PR DESCRIPTION
This change adds a pyright check to ensure that we add type hints to our code