### PR TITLE
feat: Add version number to databag for v0

### DIFF
--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -102,7 +102,13 @@ from typing import List, Mapping
 
 from jsonschema import exceptions, validate  # type: ignore[import-untyped]
 from ops import Relation
-from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+)
 from ops.framework import EventBase, EventSource, Handle, Object
 
 # The unique Charmhub library identifier, never change it
@@ -113,7 +119,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 PYDEPS = ["jsonschema"]
 
@@ -136,6 +142,7 @@ PROVIDER_JSON_SCHEMA = {
                 "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw\nNjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC\nBfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z\neqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f\nSN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS\nZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU\nAZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/\n46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ\nXN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1\nipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga\nfpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9\n49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==\n-----END CERTIFICATE-----\n",
                 "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUdiBwE/CtaBXJl3MArjZen6Y8kigwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDg1OVoXDTI0MDMyMzE4NDg1OVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJDEw\nMDdjNDBhLWUwYzMtNDVlOS05YTAxLTVlYjY0NWQ0ZmEyZDCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANOnUl6JDlXpLMRr/PxgtfE/E5Yk6E/TkPkPL/Kk\ntUGjEi42XZDg9zn3U6cjTDYu+rfKY2jiitfsduW6DQIkEpz3AvbuCMbbgnFpcjsB\nYysLSMTmuz/AVPrfnea/tQTALcONCSy1VhAjGSr81ZRSMB4khl9StSauZrbkpJ1P\nshqkFSUyAi31mKrnXz0Es/v0Yi0FzAlgWrZ4u1Ld+Bo2Xz7oK4mHf7/93Jc+tEaM\nIqG6ocD0q8bjPp0tlSxftVADNUzWlZfM6fue5EXzOsKqyDrxYOSchfU9dNzKsaBX\nkxbHEeSUPJeYYj7aVPEfAs/tlUGsoXQvwWfRie8grp2BoLECAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEACZARBpHYH6Gr2a1ka0mCWfBmOZqfDVan9rsI5TCThoylmaXW\nquEiZ2LObI+5faPzxSBhr9TjJlQamsd4ywout7pHKN8ZGqrCMRJ1jJbUfobu1n2k\nUOsY4+jzV1IRBXJzj64fLal4QhUNv341lAer6Vz3cAyRk7CK89b/DEY0x+jVpyZT\n1osx9JtsOmkDTgvdStGzq5kPKWOfjwHkmKQaZXliCgqbhzcCERppp1s/sX6K7nIh\n4lWiEmzUSD3Hngk51KGWlpZszO5KQ4cSZ3HUt/prg+tt0ROC3pY61k+m5dDUa9M8\nRtMI6iTjzSj/UV8DiAx0yeM+bKoy4jGeXmaL3g==\n-----END CERTIFICATE-----\n",
             ],
+            "version": 0,
         }
     ],
     "properties": {
@@ -157,6 +164,13 @@ PROVIDER_JSON_SCHEMA = {
             "items": {"type": "string", "$id": "#/properties/chain/items"},
             "title": "CA public TLS certificate chain",
             "description": "CA public TLS certificate chain",
+        },
+        "version": {
+            "$id": "#/properties/version",
+            "type": "integer",
+            "title": "Interface version",
+            "minimum": 0,
+            "description": "Highest supported version of this interface",
         },
     },
     "anyOf": [{"required": ["certificate"]}, {"required": ["ca"]}, {"required": ["chain"]}],
@@ -277,6 +291,7 @@ class CertificateTransferProvides(Object):
         relation.data[self.model.unit]["certificate"] = certificate
         relation.data[self.model.unit]["ca"] = ca
         relation.data[self.model.unit]["chain"] = json.dumps(chain)
+        relation.data[self.model.unit]["version"] = str(LIBAPI)
 
     def remove_certificate(self, relation_id: int) -> None:
         """Remove a given certificate from relation data.
@@ -339,6 +354,9 @@ class CertificateTransferRequires(Object):
         self.framework.observe(
             charm.on[relationship_name].relation_broken, self._on_relation_broken
         )
+        self.framework.observe(
+            charm.on[relationship_name].relation_created, self._on_relation_created
+        )
 
     @staticmethod
     def _relation_data_is_valid(relation_data: dict) -> bool:
@@ -393,9 +411,21 @@ class CertificateTransferRequires(Object):
         """
         self.on.certificate_removed.emit(relation_id=event.relation.id)
 
+    def _on_relation_created(self, event: RelationCreatedEvent) -> None:
+        """Handle relation created event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if self.model.unit.is_leader():
+            event.relation.data[self.model.app]["version"] = str(LIBAPI)
+
     def is_ready(self, relation: Relation) -> bool:
         """Check if the relation is ready by checking that it has valid relation data."""
-        relation_data = _load_relation_data(relation.data[relation.app])
+        relation_data = _load_relation_data(relation.data[relation.units.pop()])
         if not self._relation_data_is_valid(relation_data):
             logger.warning("Provider relation data did not pass JSON Schema validation: ")
             return False

--- a/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/metadata.yaml
+++ b/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/metadata.yaml
@@ -9,3 +9,9 @@ summary: Dummy certificate-transfer-interface-requirer.
 requires:
   certificates:
     interface: certificate_transfer
+
+actions:
+  is-ready:
+    params:
+      relation-id:
+        type: string

--- a/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/certificate_transfer_interface/v0/dummy_requirer_charm/src/charm.py
@@ -3,7 +3,7 @@
 
 from typing import Any
 
-from ops.charm import CharmBase
+from ops.charm import ActionEvent, CharmBase
 from ops.main import main
 
 from lib.charms.certificate_transfer_interface.v0.certificate_transfer import (
@@ -23,12 +23,20 @@ class DummyCertificateTransferRequirerCharm(CharmBase):
         self.framework.observe(
             self.certificate_transfer.on.certificate_removed, self._on_certificate_removed
         )
+        self.framework.observe(self.on.is_ready_action, self._on_is_ready_action)
 
-    def _on_certificate_available(self, event: CertificateAvailableEvent):
+    def _on_certificate_available(self, _: CertificateAvailableEvent):
         pass
 
-    def _on_certificate_removed(self, event: CertificateRemovedEvent):
+    def _on_certificate_removed(self, _: CertificateRemovedEvent):
         pass
+
+    def _on_is_ready_action(self, event: ActionEvent):
+        rel = self.model.get_relation("certificates", int(event.params["relation-id"]))
+        if rel:
+            event.set_results({"ready": self.certificate_transfer.is_ready(rel)})
+        else:
+            event.set_results({"ready": False})
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,14 @@ min_version = 4.0.0
 
 [vars]
 src_path = {toxinidir}/src/
-lib_path = {toxinidir}/lib/charms/certificate_transfer_interface/
+lib_path = {toxinidir}/lib/
 unit_test_path = {toxinidir}/tests/unit/
+integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]lib_path}
 
 [testenv]
+runner = uv-venv-lock-runner
+with_dev = true
 set_env =
     PYTHONPATH = {tox_root}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=pdb.set_trace
@@ -49,5 +52,5 @@ commands =
 [testenv:unit]
 description = Run unit tests
 commands =
-    coverage run --source={[vars]src_path},{[vars]lib_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
+    coverage run --source={[vars]lib_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
     coverage report


### PR DESCRIPTION
# Description

This PR adds the version number to both databags on version 0 of the library. This change follows spec TE175 and will be used to build an upgrade path between v0 and v1 in the future.

The PR also refactors the unit tests for v0 to use scenario, as harness is deprecated.

While working on the tests refactoring, I noticed that `is_ready` could never return `True` in the real world, as it was looking at the application databag, and the provider only writes to the unit databag. This bug is also fixed in this PR.

This will require a matching change in the `charm-relation-interfaces` project.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
