### PR TITLE
fix: Make sure only leader unit modifies app data

### DIFF
--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -116,7 +116,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 
@@ -438,6 +438,9 @@ class CertificateTransferRequires(Object):
         Returns:
             None
         """
+        if not self.model.unit.is_leader():
+            logger.debug("Only leader unit sets the version number in the app databag")
+            return
         databag = event.relation.data[self.model.app]
         RequirerApplicationData().dump(databag, False)
 

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
@@ -77,6 +77,25 @@ class TestCertificateTransferRequiresV1:
 
         assert relation.local_app_data["version"] == "1"
 
+    def test_given_is_not_leader_when_relation_created_then_debug_message_is_logged(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        relation = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+        )
+        state_in = scenario.State(leader=False, relations=[relation])
+
+        self.ctx.run(self.ctx.on.relation_created(relation), state_in)
+
+        logs = [(record.levelname, record.module, record.message) for record in caplog.records]
+        assert (
+            "DEBUG",
+            "certificate_transfer",
+            "Only leader unit sets the version number in the app databag",
+        ) in logs
+
     def test_given_certificates_in_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(
         self,
     ):


### PR DESCRIPTION
# Description

Adds a guard so only the leader unit can set version number in app databag.
Adds a test to ensure the guard is there.
fixes #148 

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
