### PR TITLE
feat: add ability for providers to remove all certificates

### DIFF
--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -116,7 +116,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 
@@ -243,7 +243,7 @@ class CertificateTransferProvides(Object):
             None
         """
         if not self.charm.unit.is_leader():
-            logger.error("Only the leader unit can add certificates to this relation")
+            logger.warning("Only the leader unit can add certificates to this relation")
             return
         relations = self._get_relevant_relations(relation_id)
         if not relations:
@@ -257,6 +257,31 @@ class CertificateTransferProvides(Object):
             existing_data = self._get_relation_data(relation)
             existing_data.update(certificates)
             self._set_relation_data(relation, existing_data)
+
+    def remove_all_certificates(self, relation_id: Optional[int] = None) -> None:
+        """Remove all certificates from relation data.
+
+        Removes all certificates from all relations if relation_id not given
+
+        Args:
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning("Only the leader unit can add certificates to this relation")
+            return
+        relations = self._get_relevant_relations(relation_id)
+        if not relations:
+            logger.error(
+                "At least 1 matching relation ID not found with the relation name '%s'",
+                self.relationship_name,
+            )
+            return
+
+        for relation in relations:
+            self._set_relation_data(relation, set())
 
     def remove_certificate(
         self,
@@ -275,7 +300,7 @@ class CertificateTransferProvides(Object):
             None
         """
         if not self.charm.unit.is_leader():
-            logger.error("Only the leader unit can add certificates to this relation")
+            logger.warning("Only the leader unit can add certificates to this relation")
             return
         relations = self._get_relevant_relations(relation_id)
         if not relations:
@@ -438,6 +463,9 @@ class CertificateTransferRequires(Object):
         Returns:
             None
         """
+        if not self.model.unit.is_leader():
+            logger.debug("Only leader unit sets the version number in the app databag")
+            return
         databag = event.relation.data[self.model.app]
         RequirerApplicationData().dump(databag, False)
 

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
@@ -77,6 +77,25 @@ class TestCertificateTransferRequiresV1:
 
         assert relation.local_app_data["version"] == "1"
 
+    def test_given_is_not_leader_when_relation_created_then_debug_message_is_logged(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        relation = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+        )
+        state_in = scenario.State(leader=False, relations=[relation])
+
+        self.ctx.run(self.ctx.on.relation_created(relation), state_in)
+
+        logs = [(record.levelname, record.module, record.message) for record in caplog.records]
+        assert (
+            "DEBUG",
+            "certificate_transfer",
+            "Only leader unit sets the version number in the app databag",
+        ) in logs
+
     def test_given_certificates_in_relation_data_when_relation_changed_then_certificate_available_event_is_emitted(
         self,
     ):


### PR DESCRIPTION
# Description

In `v0`, providers had the ability to remove the certificate from the relation without knowing the content of the certificate. Here we add a similar feature, allowing the provider to remove all the certificates from the relation. This feature is needed in the Vault charms.

## Checklist

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
