### PR TITLE
fix: Change missing relation log level to warning

### DIFF
--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -317,7 +317,7 @@ class CertificateTransferProvides(Object):
             return
         relations = self._get_relevant_relations(relation_id)
         if not relations:
-            logger.error(
+            logger.warning(
                 "At least 1 matching relation ID not found with the relation name '%s'",
                 self.relationship_name,
             )
@@ -344,7 +344,7 @@ class CertificateTransferProvides(Object):
             return
         relations = self._get_relevant_relations(relation_id)
         if not relations:
-            logger.error(
+            logger.warning(
                 "At least 1 matching relation ID not found with the relation name '%s'",
                 self.relationship_name,
             )
@@ -374,7 +374,7 @@ class CertificateTransferProvides(Object):
             return
         relations = self._get_relevant_relations(relation_id)
         if not relations:
-            logger.error(
+            logger.warning(
                 "At least 1 matching relation ID not found with the relation name '%s'",
                 self.relationship_name,
             )

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
@@ -91,7 +91,7 @@ class TestCertificateTransferProvidesV1:
 
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         assert (
-            "ERROR",
+            "WARNING",
             "certificate_transfer",
             "At least 1 matching relation ID not found with the relation name 'certificate_transfer'",
         ) in logs
@@ -117,7 +117,7 @@ class TestCertificateTransferProvidesV1:
 
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         assert (
-            "ERROR",
+            "WARNING",
             "certificate_transfer",
             "At least 1 matching relation ID not found with the relation name 'certificate_transfer'",
         ) in logs
@@ -260,7 +260,7 @@ the databags except using the public methods in the provider library and use ver
 
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         assert (
-            "ERROR",
+            "WARNING",
             "certificate_transfer",
             "At least 1 matching relation ID not found with the relation name 'certificate_transfer'",
         ) in logs
@@ -286,7 +286,7 @@ the databags except using the public methods in the provider library and use ver
 
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         assert (
-            "ERROR",
+            "WARNING",
             "certificate_transfer",
             "At least 1 matching relation ID not found with the relation name 'certificate_transfer'",
         ) in logs


### PR DESCRIPTION
# Description

When the relation is not used on a provider, the library was logging at the error level for no reason. This PR reduces the log level to warning in this case.

Will fix https://github.com/canonical/self-signed-certificates-operator/issues/358

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
