### PR TITLE
feat: Add backwards compatibility between v1 and v0

### DIFF
--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
@@ -171,13 +171,19 @@ the databags except using the public methods in the provider library and use ver
         self,
     ):
         relation_1 = scenario.Relation(
-            endpoint="certificate_transfer", interface="certificate_transfer"
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "1"},
         )
         relation_2 = scenario.Relation(
-            endpoint="certificate_transfer", interface="certificate_transfer"
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "1"},
         )
         relation_3 = scenario.Relation(
-            endpoint="certificate_transfer", interface="certificate_transfer"
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "0"},
         )
         state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])
 
@@ -202,22 +208,41 @@ the databags except using the public methods in the provider library and use ver
         ]
         assert set(json.loads(certificates_relation_1)) == {"certificate1", "certificate2"}
         assert set(json.loads(certificates_relation_2)) == {"certificate1", "certificate2"}
-        assert set(json.loads(certificates_relation_3)) == {"certificate1", "certificate2"}
+        relation_3_databag = json.loads(certificates_relation_3)
+        assert len(relation_3_databag) == 2
+        assert {
+            "certificate": "certificate1",
+            "ca": "certificate1",
+            "chain": ["certificate1"],
+            "version": 0,
+        } in relation_3_databag
+        assert {
+            "certificate": "certificate2",
+            "ca": "certificate2",
+            "chain": ["certificate2"],
+            "version": 0,
+        } in relation_3_databag
         assert state_out.get_relation(relation_1.id).local_app_data["version"] == "1"
         assert state_out.get_relation(relation_2.id).local_app_data["version"] == "1"
-        assert state_out.get_relation(relation_3.id).local_app_data["version"] == "1"
+        assert "version" not in state_out.get_relation(relation_3.id).local_app_data
 
     def test_given_multiple_relations_when_add_certificates_with_relation_id_then_certificate_sent_to_specific_relation(
         self,
     ):
         relation_1 = scenario.Relation(
-            endpoint="certificate_transfer", interface="certificate_transfer"
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "1"},
         )
         relation_2 = scenario.Relation(
-            endpoint="certificate_transfer", interface="certificate_transfer"
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "1"},
         )
         relation_3 = scenario.Relation(
-            endpoint="certificate_transfer", interface="certificate_transfer"
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "0"},
         )
         state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])
 
@@ -233,8 +258,7 @@ the databags except using the public methods in the provider library and use ver
         )
 
         relation_1_app_data = state_out.get_relation(relation_1.id).local_app_data
-        assert "certificates" not in relation_1_app_data
-        assert "version" not in relation_1_app_data
+        assert relation_1_app_data == {}
         relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
         assert set(json.loads(relation_2_app_data["certificates"])) == {
             "certificate1",
@@ -242,8 +266,58 @@ the databags except using the public methods in the provider library and use ver
         }
         assert state_out.get_relation(relation_2.id).local_app_data["version"] == "1"
         relation_3_app_data = state_out.get_relation(relation_3.id).local_app_data
-        assert "certificates" not in relation_3_app_data
-        assert "version" not in relation_3_app_data
+        assert relation_3_app_data == {}
+
+    def test_given_multiple_relations_when_add_certificates_with_relation_id_v0_then_certificate_sent_to_specific_relation(
+        self,
+    ):
+        relation_1 = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "1"},
+        )
+        relation_2 = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "1"},
+        )
+        relation_3 = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "0"},
+        )
+        state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])
+
+        state_out = self.ctx.run(
+            self.ctx.on.action(
+                "add-certificates",
+                params={
+                    "certificates": "certificate1, certificate2",
+                    "relation-id": str(relation_3.id),
+                },
+            ),
+            state_in,
+        )
+
+        relation_1_app_data = state_out.get_relation(relation_1.id).local_app_data
+        assert relation_1_app_data == {}
+        relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
+        assert relation_2_app_data == {}
+        relation_3_app_data = state_out.get_relation(relation_3.id).local_app_data
+        relation_3_databag = json.loads(relation_3_app_data["certificates"])
+        assert len(relation_3_databag) == 2
+        assert {
+            "certificate": "certificate1",
+            "ca": "certificate1",
+            "chain": ["certificate1"],
+            "version": 0,
+        } in relation_3_databag
+        assert {
+            "certificate": "certificate2",
+            "ca": "certificate2",
+            "chain": ["certificate2"],
+            "version": 0,
+        } in relation_3_databag
 
     def test_given_no_relation_when_remove_certificate_then_error_is_logged(
         self, caplog: pytest.LogCaptureFixture
@@ -297,17 +371,37 @@ the databags except using the public methods in the provider library and use ver
         relation_1 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         relation_2 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         relation_3 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
-            local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
+            remote_app_data={"version": "0"},
+            local_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": "certificate1",
+                            "ca": "certificate1",
+                            "chain": ["certificate1"],
+                            "version": 0,
+                        },
+                        {
+                            "certificate": "certificate2",
+                            "ca": "certificate2",
+                            "chain": ["certificate2"],
+                            "version": 0,
+                        },
+                    ]
+                )
+            },
         )
         state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])
 
@@ -332,7 +426,14 @@ the databags except using the public methods in the provider library and use ver
         ]
         assert set(json.loads(certificates_relation_1)) == {"certificate2"}
         assert set(json.loads(certificates_relation_2)) == {"certificate2"}
-        assert set(json.loads(certificates_relation_3)) == {"certificate2"}
+        relation_3_databag = json.loads(certificates_relation_3)
+        assert len(relation_3_databag) == 1
+        assert {
+            "certificate": "certificate2",
+            "ca": "certificate2",
+            "chain": ["certificate2"],
+            "version": 0,
+        } in relation_3_databag
 
     def test_given_multiple_relations_when_remove_certificate_with_relation_id_then_certificate_removed_from_specific_relation(
         self,
@@ -340,17 +441,37 @@ the databags except using the public methods in the provider library and use ver
         relation_1 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         relation_2 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         relation_3 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
-            local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
+            remote_app_data={"version": "0"},
+            local_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": "certificate1",
+                            "ca": "certificate1",
+                            "chain": ["certificate1"],
+                            "version": 0,
+                        },
+                        {
+                            "certificate": "certificate2",
+                            "ca": "certificate2",
+                            "chain": ["certificate2"],
+                            "version": 0,
+                        },
+                    ]
+                )
+            },
         )
         state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])
 
@@ -373,10 +494,91 @@ the databags except using the public methods in the provider library and use ver
         relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
         assert set(json.loads(relation_2_app_data["certificates"])) == {"certificate2"}
         relation_3_app_data = state_out.get_relation(relation_3.id).local_app_data
-        assert set(json.loads(relation_3_app_data["certificates"])) == {
+        relation_3_databag = json.loads(relation_3_app_data["certificates"])
+        assert len(relation_3_databag) == 2
+        assert {
+            "certificate": "certificate1",
+            "ca": "certificate1",
+            "chain": ["certificate1"],
+            "version": 0,
+        } in relation_3_databag
+        assert {
+            "certificate": "certificate2",
+            "ca": "certificate2",
+            "chain": ["certificate2"],
+            "version": 0,
+        } in relation_3_databag
+
+    def test_given_multiple_relations_when_remove_certificate_with_relation_id_v0_then_certificate_removed_from_specific_relation(
+        self,
+    ):
+        relation_1 = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "1"},
+            local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
+        )
+        relation_2 = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "1"},
+            local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
+        )
+        relation_3 = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={"version": "0"},
+            local_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": "certificate1",
+                            "ca": "certificate1",
+                            "chain": ["certificate1"],
+                            "version": 0,
+                        },
+                        {
+                            "certificate": "certificate2",
+                            "ca": "certificate2",
+                            "chain": ["certificate2"],
+                            "version": 0,
+                        },
+                    ]
+                )
+            },
+        )
+        state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])
+
+        state_out = self.ctx.run(
+            self.ctx.on.action(
+                "remove-certificate",
+                params={
+                    "certificate": "certificate1",
+                    "relation-id": str(relation_3.id),
+                },
+            ),
+            state_in,
+        )
+
+        relation_1_app_data = state_out.get_relation(relation_1.id).local_app_data
+        assert set(json.loads(relation_1_app_data["certificates"])) == {
             "certificate1",
             "certificate2",
         }
+        relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
+        assert set(json.loads(relation_2_app_data["certificates"])) == {
+            "certificate1",
+            "certificate2",
+        }
+        relation_3_app_data = state_out.get_relation(relation_3.id).local_app_data
+        relation_3_databag = json.loads(relation_3_app_data["certificates"])
+        assert len(relation_3_databag) == 1
+        assert {
+            "certificate": "certificate2",
+            "ca": "certificate2",
+            "chain": ["certificate2"],
+            "version": 0,
+        } in relation_3_databag
 
     def test_given_multiple_relations_when_remove_all_certificates_then_certificates_removed_from_all_relations(
         self,

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
@@ -116,6 +116,34 @@ class TestCertificateTransferRequiresV1:
         assert self.ctx.emitted_events[1].certificates == {"cert1"}
         assert self.ctx.emitted_events[1].relation_id == relation.id
 
+    def test_given_certificates_in_relation_data_in_v0_when_relation_changed_then_certificate_available_event_is_emitted(
+        self,
+    ):
+        relation = scenario.Relation(
+            endpoint="certificate_transfer",
+            interface="certificate_transfer",
+            remote_app_data={
+                "certificates": json.dumps(
+                    [
+                        {
+                            "certificate": "cert1",
+                            "ca": "cert1",
+                            "chain": ["cert1"],
+                            "version": 0,
+                        }
+                    ]
+                )
+            },
+        )
+        state_in = scenario.State(relations=[relation])
+
+        self.ctx.run(self.ctx.on.relation_changed(relation), state_in)
+
+        assert len(self.ctx.emitted_events) == 2
+        assert isinstance(self.ctx.emitted_events[1], CertificatesAvailableEvent)
+        assert self.ctx.emitted_events[1].certificates == {"cert1"}
+        assert self.ctx.emitted_events[1].relation_id == relation.id
+
     def test_given_none_of_the_expected_keys_in_relation_data_when_relation_changed_then_certificate_available_event_emitted_with_empty_cert(
         self,
     ):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 no_package = True
 skip_missing_interpreters = True
-env_list = format, lint, static, unit
+env_list = lint, static, unit
 min_version = 4.0.0
 
 [vars]


### PR DESCRIPTION
# Description

This PR adds backwards compatibility between v1 and v0. It is required to decouple the upgrade of the library between requirers and providers, allowing us to add proper support for this interface to different providers, without tying us to v0.

Providers using this library will first check if the remote app has written a version number to their databag. If yes and it is version 1, we use v1 of the interface; otherwise, we use v0.

Requirers using this library still write version 1 on relation created, and should receive the data with v1 of the interface. However, that could lead to a race condition between the requirer and provider. Thus, if the requirer is not able to read the databag with v1, it will fallback to reading it in v0 and converting it on the spot to v1, by using the `ca` attribute.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
