### PR TITLE
fix: Backwards compatibility with v0 needs to use unit databag

### DIFF
--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -124,7 +124,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 logger = logging.getLogger(__name__)
 
@@ -303,8 +303,8 @@ class _Certificate(pydantic.BaseModel):
     )
 
 
-class ProviderApplicationDataV0(DatabagModel):
-    """Provider App databag v0 model."""
+class ProviderUnitDataV0(DatabagModel):
+    """Provider Unit databag v0 model."""
 
     certificates: List[_Certificate] = []
 
@@ -408,6 +408,7 @@ class CertificateTransferProvides(Object):
 
         for relation in relations:
             existing_data = self._get_relation_data(relation)
+            logger.error(existing_data)
             existing_data.discard(certificate)
             self._set_relation_data(relation, existing_data)
 
@@ -451,20 +452,20 @@ class CertificateTransferProvides(Object):
                     relation.id,
                 )
 
-            databag = relation.data[self.model.app]
+            databag = relation.data[self.model.unit]
             certificates = [_Certificate(ca=cert, certificate=cert, chain=[cert]) for cert in data]
-            ProviderApplicationDataV0(certificates=certificates).dump(databag, True)
+            ProviderUnitDataV0(certificates=certificates).dump(databag, True)
 
     def _get_relation_data(self, relation: Relation) -> Set[str]:
         """Get the given relation data."""
-        databag = relation.data[self.model.app]
         try:
-            return ProviderApplicationData().load(databag).certificates
+            if relation.data.get(relation.app, {}).get("version", "0") == "1":
+                databag = relation.data[self.model.app]
+                return ProviderApplicationData().load(databag).certificates
+            else:
+                databag = relation.data[self.model.unit]
+                return {cert.ca for cert in ProviderUnitDataV0().load(databag).certificates}
         except DataValidationError as e:
-            try:
-                return {cert.ca for cert in ProviderApplicationDataV0().load(databag).certificates}
-            except DataValidationError:
-                pass
             logger.error(
                 (
                     "Error parsing relation databag: %s. ",
@@ -623,14 +624,14 @@ class CertificateTransferRequires(Object):
 
     def _get_relation_data(self, relation: Relation) -> Set[str]:
         """Get the given relation data."""
-        databag = relation.data[relation.app]
         try:
-            return ProviderApplicationData().load(databag).certificates
+            databag = relation.data[relation.app]
+            certificates = ProviderApplicationData().load(databag).certificates
+            if not certificates:
+                databag = relation.data[relation.units.pop()]
+                return {cert.ca for cert in ProviderUnitDataV0().load(databag).certificates}
+            return certificates
         except DataValidationError as e:
-            try:
-                return {cert.ca for cert in ProviderApplicationDataV0().load(databag).certificates}
-            except DataValidationError:
-                pass
             logger.error(
                 (
                     "Error parsing relation databag: %s. ",

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
@@ -145,6 +145,7 @@ the databags except using the public methods in the provider library and use ver
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": databag_value},
         )
         state_in = scenario.State(leader=True, relations=[relation])
@@ -203,7 +204,7 @@ the databags except using the public methods in the provider library and use ver
         certificates_relation_2 = state_out.get_relation(relation_2.id).local_app_data[
             "certificates"
         ]
-        certificates_relation_3 = state_out.get_relation(relation_3.id).local_app_data[
+        certificates_relation_3 = state_out.get_relation(relation_3.id).local_unit_data[
             "certificates"
         ]
         assert set(json.loads(certificates_relation_1)) == {"certificate1", "certificate2"}
@@ -303,8 +304,8 @@ the databags except using the public methods in the provider library and use ver
         assert relation_1_app_data == {}
         relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
         assert relation_2_app_data == {}
-        relation_3_app_data = state_out.get_relation(relation_3.id).local_app_data
-        relation_3_databag = json.loads(relation_3_app_data["certificates"])
+        relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
+        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
         assert len(relation_3_databag) == 2
         assert {
             "certificate": "certificate1",
@@ -367,8 +368,8 @@ the databags except using the public methods in the provider library and use ver
         assert relation_1_app_data == {}
         relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
         assert relation_2_app_data == {}
-        relation_3_app_data = state_out.get_relation(relation_3.id).local_app_data
-        relation_3_databag = json.loads(relation_3_app_data["certificates"])
+        relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
+        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
         assert len(relation_3_databag) == 2
         assert {
             "certificate": "certificate1",
@@ -462,7 +463,7 @@ the databags except using the public methods in the provider library and use ver
             endpoint="certificate_transfer",
             interface="certificate_transfer",
             remote_app_data={"version": "0"},
-            local_app_data={
+            local_unit_data={
                 "certificates": json.dumps(
                     [
                         {
@@ -484,7 +485,7 @@ the databags except using the public methods in the provider library and use ver
         relation_4 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
-            local_app_data={
+            local_unit_data={
                 "certificates": json.dumps(
                     [
                         {
@@ -523,10 +524,10 @@ the databags except using the public methods in the provider library and use ver
         certificates_relation_2 = state_out.get_relation(relation_2.id).local_app_data[
             "certificates"
         ]
-        certificates_relation_3 = state_out.get_relation(relation_3.id).local_app_data[
+        certificates_relation_3 = state_out.get_relation(relation_3.id).local_unit_data[
             "certificates"
         ]
-        certificates_relation_4 = state_out.get_relation(relation_4.id).local_app_data[
+        certificates_relation_4 = state_out.get_relation(relation_4.id).local_unit_data[
             "certificates"
         ]
         assert set(json.loads(certificates_relation_1)) == {"certificate2"}
@@ -567,7 +568,7 @@ the databags except using the public methods in the provider library and use ver
             endpoint="certificate_transfer",
             interface="certificate_transfer",
             remote_app_data={"version": "0"},
-            local_app_data={
+            local_unit_data={
                 "certificates": json.dumps(
                     [
                         {
@@ -589,7 +590,7 @@ the databags except using the public methods in the provider library and use ver
         relation_4 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
-            local_app_data={
+            local_unit_data={
                 "certificates": json.dumps(
                     [
                         {
@@ -630,8 +631,8 @@ the databags except using the public methods in the provider library and use ver
         }
         relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
         assert set(json.loads(relation_2_app_data["certificates"])) == {"certificate2"}
-        relation_3_app_data = state_out.get_relation(relation_3.id).local_app_data
-        relation_3_databag = json.loads(relation_3_app_data["certificates"])
+        relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
+        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
         assert len(relation_3_databag) == 2
         assert {
             "certificate": "certificate1",
@@ -645,8 +646,8 @@ the databags except using the public methods in the provider library and use ver
             "chain": ["certificate2"],
             "version": 0,
         } in relation_3_databag
-        relation_4_app_data = state_out.get_relation(relation_4.id).local_app_data
-        relation_4_databag = json.loads(relation_4_app_data["certificates"])
+        relation_4_unit_data = state_out.get_relation(relation_4.id).local_unit_data
+        relation_4_databag = json.loads(relation_4_unit_data["certificates"])
         assert len(relation_4_databag) == 2
         assert {
             "certificate": "certificate1",
@@ -680,7 +681,7 @@ the databags except using the public methods in the provider library and use ver
             endpoint="certificate_transfer",
             interface="certificate_transfer",
             remote_app_data={"version": "0"},
-            local_app_data={
+            local_unit_data={
                 "certificates": json.dumps(
                     [
                         {
@@ -722,8 +723,8 @@ the databags except using the public methods in the provider library and use ver
             "certificate1",
             "certificate2",
         }
-        relation_3_app_data = state_out.get_relation(relation_3.id).local_app_data
-        relation_3_databag = json.loads(relation_3_app_data["certificates"])
+        relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
+        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
         assert len(relation_3_databag) == 1
         assert {
             "certificate": "certificate2",
@@ -750,7 +751,7 @@ the databags except using the public methods in the provider library and use ver
         relation_3 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
-            local_app_data={
+            local_unit_data={
                 "certificates": json.dumps(
                     [
                         {
@@ -792,8 +793,8 @@ the databags except using the public methods in the provider library and use ver
             "certificate1",
             "certificate2",
         }
-        relation_3_app_data = state_out.get_relation(relation_3.id).local_app_data
-        relation_3_databag = json.loads(relation_3_app_data["certificates"])
+        relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
+        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
         assert len(relation_3_databag) == 1
         assert {
             "certificate": "certificate2",
@@ -808,16 +809,19 @@ the databags except using the public methods in the provider library and use ver
         relation_1 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         relation_2 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         relation_3 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])
@@ -848,16 +852,19 @@ the databags except using the public methods in the provider library and use ver
         relation_1 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         relation_2 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         relation_3 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            remote_app_data={"version": "1"},
             local_app_data={"certificates": json.dumps(["certificate1", "certificate2"])},
         )
         state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
@@ -71,6 +71,7 @@ class TestCertificateTransferRequiresV1:
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            local_app_data={"version": "1"},
         )
         state_in = scenario.State(leader=True, relations=[relation])
 
@@ -87,6 +88,7 @@ class TestCertificateTransferRequiresV1:
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            local_app_data={"version": "1"},
         )
         state_in = scenario.State(leader=False, relations=[relation])
 
@@ -105,6 +107,7 @@ class TestCertificateTransferRequiresV1:
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            local_app_data={"version": "1"},
             remote_app_data={"certificates": json.dumps(["cert1"])},
         )
         state_in = scenario.State(relations=[relation])
@@ -122,17 +125,20 @@ class TestCertificateTransferRequiresV1:
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
-            remote_app_data={
-                "certificates": json.dumps(
-                    [
-                        {
-                            "certificate": "cert1",
-                            "ca": "cert1",
-                            "chain": ["cert1"],
-                            "version": 0,
-                        }
-                    ]
-                )
+            local_app_data={"version": "1"},
+            remote_units_data={
+                0: {
+                    "certificates": json.dumps(
+                        [
+                            {
+                                "certificate": "cert1",
+                                "ca": "cert1",
+                                "chain": ["cert1"],
+                                "version": 0,
+                            }
+                        ]
+                    )
+                }
             },
         )
         state_in = scenario.State(relations=[relation])
@@ -150,6 +156,7 @@ class TestCertificateTransferRequiresV1:
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            local_app_data={"version": "1"},
             remote_app_data={"bad-key": json.dumps(["cert1"])},
         )
         state_in = scenario.State(relations=[relation])
@@ -167,6 +174,7 @@ class TestCertificateTransferRequiresV1:
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            local_app_data={"version": "1"},
             remote_app_data={"certificates": json.dumps(["cert1"])},
         )
         state_in = scenario.State(relations=[relation])
@@ -210,6 +218,7 @@ the databags except using the public methods in the provider library and use ver
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            local_app_data={"version": "1"},
             remote_app_data={"certificates": databag_value},
         )
         state_in = scenario.State(leader=True, relations=[relation])
@@ -227,6 +236,7 @@ the databags except using the public methods in the provider library and use ver
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            local_app_data={"version": "1"},
             remote_app_data={"certificates": "some string"},
         )
         state_in = scenario.State(leader=True, relations=[relation])
@@ -242,6 +252,7 @@ the databags except using the public methods in the provider library and use ver
         relation = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
+            local_app_data={"version": "1"},
             remote_app_data={"certificates": json.dumps(["cert1"])},
         )
         state_in = scenario.State(leader=True, relations=[relation])


### PR DESCRIPTION
# Description

The previous PR adding backwards compatibility to lib v1 for interface v0 was flawed, as the interface v0 uses the unit databag from the provider side. This PR fixes the issue.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
