### PR TITLE
fix: Fix a crash when a relation exists with no remote units

### DIFF
--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -124,7 +124,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 logger = logging.getLogger(__name__)
 
@@ -626,8 +626,8 @@ class CertificateTransferRequires(Object):
         try:
             databag = relation.data[relation.app]
             certificates = ProviderApplicationData().load(databag).certificates
-            if not certificates:
-                databag = relation.data[relation.units.pop()]
+            if not certificates and relation.units:
+                databag = relation.data.get(relation.units.pop(), {})
                 return {cert.ca for cert in ProviderUnitDataV0().load(databag).certificates}
             return certificates
         except DataValidationError as e:


### PR DESCRIPTION
# Description

This fixes a crash for requirers when the `certificate_transfer` exists but no remote units are present yet. This can happen with Juju right after the relation is created.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
