### PR TITLE
fix: Fix v0 interface compatiblity in v1 library

### DIFF
--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_provides_v1.py
@@ -204,25 +204,10 @@ the databags except using the public methods in the provider library and use ver
         certificates_relation_2 = state_out.get_relation(relation_2.id).local_app_data[
             "certificates"
         ]
-        certificates_relation_3 = state_out.get_relation(relation_3.id).local_unit_data[
-            "certificates"
-        ]
+        certificates_relation_3 = state_out.get_relation(relation_3.id).local_unit_data["chain"]
         assert set(json.loads(certificates_relation_1)) == {"certificate1", "certificate2"}
         assert set(json.loads(certificates_relation_2)) == {"certificate1", "certificate2"}
-        relation_3_databag = json.loads(certificates_relation_3)
-        assert len(relation_3_databag) == 2
-        assert {
-            "certificate": "certificate1",
-            "ca": "certificate1",
-            "chain": ["certificate1"],
-            "version": 0,
-        } in relation_3_databag
-        assert {
-            "certificate": "certificate2",
-            "ca": "certificate2",
-            "chain": ["certificate2"],
-            "version": 0,
-        } in relation_3_databag
+        assert set(json.loads(certificates_relation_3)) == {"certificate1", "certificate2"}
         assert state_out.get_relation(relation_1.id).local_app_data["version"] == "1"
         assert state_out.get_relation(relation_2.id).local_app_data["version"] == "1"
         assert "version" not in state_out.get_relation(relation_3.id).local_app_data
@@ -305,20 +290,9 @@ the databags except using the public methods in the provider library and use ver
         relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
         assert relation_2_app_data == {}
         relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
-        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
+        relation_3_databag = set(json.loads(relation_3_unit_data["chain"]))
         assert len(relation_3_databag) == 2
-        assert {
-            "certificate": "certificate1",
-            "ca": "certificate1",
-            "chain": ["certificate1"],
-            "version": 0,
-        } in relation_3_databag
-        assert {
-            "certificate": "certificate2",
-            "ca": "certificate2",
-            "chain": ["certificate2"],
-            "version": 0,
-        } in relation_3_databag
+        assert relation_3_databag == {"certificate1", "certificate2"}
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         expected_msg = str(
             (
@@ -369,20 +343,9 @@ the databags except using the public methods in the provider library and use ver
         relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
         assert relation_2_app_data == {}
         relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
-        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
+        relation_3_databag = set(json.loads(relation_3_unit_data["chain"]))
         assert len(relation_3_databag) == 2
-        assert {
-            "certificate": "certificate1",
-            "ca": "certificate1",
-            "chain": ["certificate1"],
-            "version": 0,
-        } in relation_3_databag
-        assert {
-            "certificate": "certificate2",
-            "ca": "certificate2",
-            "chain": ["certificate2"],
-            "version": 0,
-        } in relation_3_databag
+        assert relation_3_databag == {"certificate1", "certificate2"}
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         expected_msg = str(
             (
@@ -464,44 +427,20 @@ the databags except using the public methods in the provider library and use ver
             interface="certificate_transfer",
             remote_app_data={"version": "0"},
             local_unit_data={
-                "certificates": json.dumps(
-                    [
-                        {
-                            "certificate": "certificate1",
-                            "ca": "certificate1",
-                            "chain": ["certificate1"],
-                            "version": 0,
-                        },
-                        {
-                            "certificate": "certificate2",
-                            "ca": "certificate2",
-                            "chain": ["certificate2"],
-                            "version": 0,
-                        },
-                    ]
-                )
+                "certificate": json.dumps("certificate1"),
+                "ca": json.dumps("certificate1"),
+                "chain": json.dumps(["certificate1", "certificate2"]),
+                "version": json.dumps(0),
             },
         )
         relation_4 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
             local_unit_data={
-                "certificates": json.dumps(
-                    [
-                        {
-                            "certificate": "certificate1",
-                            "ca": "certificate1",
-                            "chain": ["certificate1"],
-                            "version": 0,
-                        },
-                        {
-                            "certificate": "certificate2",
-                            "ca": "certificate2",
-                            "chain": ["certificate2"],
-                            "version": 0,
-                        },
-                    ]
-                )
+                "certificate": json.dumps("certificate1"),
+                "ca": json.dumps("certificate1"),
+                "chain": json.dumps(["certificate1", "certificate2"]),
+                "version": json.dumps(0),
             },
         )
         state_in = scenario.State(
@@ -524,30 +463,12 @@ the databags except using the public methods in the provider library and use ver
         certificates_relation_2 = state_out.get_relation(relation_2.id).local_app_data[
             "certificates"
         ]
-        certificates_relation_3 = state_out.get_relation(relation_3.id).local_unit_data[
-            "certificates"
-        ]
-        certificates_relation_4 = state_out.get_relation(relation_4.id).local_unit_data[
-            "certificates"
-        ]
+        certificates_relation_3 = state_out.get_relation(relation_3.id).local_unit_data["chain"]
+        certificates_relation_4 = state_out.get_relation(relation_4.id).local_unit_data["chain"]
         assert set(json.loads(certificates_relation_1)) == {"certificate2"}
         assert set(json.loads(certificates_relation_2)) == {"certificate2"}
-        relation_3_databag = json.loads(certificates_relation_3)
-        assert len(relation_3_databag) == 1
-        assert {
-            "certificate": "certificate2",
-            "ca": "certificate2",
-            "chain": ["certificate2"],
-            "version": 0,
-        } in relation_3_databag
-        relation_4_databag = json.loads(certificates_relation_4)
-        assert len(relation_4_databag) == 1
-        assert {
-            "certificate": "certificate2",
-            "ca": "certificate2",
-            "chain": ["certificate2"],
-            "version": 0,
-        } in relation_4_databag
+        assert set(json.loads(certificates_relation_3)) == {"certificate2"}
+        assert set(json.loads(certificates_relation_4)) == {"certificate2"}
 
     def test_given_multiple_relations_when_remove_certificate_with_relation_id_then_certificate_removed_from_specific_relation(
         self,
@@ -569,44 +490,20 @@ the databags except using the public methods in the provider library and use ver
             interface="certificate_transfer",
             remote_app_data={"version": "0"},
             local_unit_data={
-                "certificates": json.dumps(
-                    [
-                        {
-                            "certificate": "certificate1",
-                            "ca": "certificate1",
-                            "chain": ["certificate1"],
-                            "version": 0,
-                        },
-                        {
-                            "certificate": "certificate2",
-                            "ca": "certificate2",
-                            "chain": ["certificate2"],
-                            "version": 0,
-                        },
-                    ]
-                )
+                "certificate": json.dumps("certificate1"),
+                "ca": json.dumps("certificate1"),
+                "chain": json.dumps(["certificate1", "certificate2"]),
+                "version": json.dumps(0),
             },
         )
         relation_4 = scenario.Relation(
             endpoint="certificate_transfer",
             interface="certificate_transfer",
             local_unit_data={
-                "certificates": json.dumps(
-                    [
-                        {
-                            "certificate": "certificate1",
-                            "ca": "certificate1",
-                            "chain": ["certificate1"],
-                            "version": 0,
-                        },
-                        {
-                            "certificate": "certificate2",
-                            "ca": "certificate2",
-                            "chain": ["certificate2"],
-                            "version": 0,
-                        },
-                    ]
-                )
+                "certificate": json.dumps("certificate1"),
+                "ca": json.dumps("certificate1"),
+                "chain": json.dumps(["certificate1", "certificate2"]),
+                "version": json.dumps(0),
             },
         )
         state_in = scenario.State(
@@ -632,35 +529,9 @@ the databags except using the public methods in the provider library and use ver
         relation_2_app_data = state_out.get_relation(relation_2.id).local_app_data
         assert set(json.loads(relation_2_app_data["certificates"])) == {"certificate2"}
         relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
-        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
-        assert len(relation_3_databag) == 2
-        assert {
-            "certificate": "certificate1",
-            "ca": "certificate1",
-            "chain": ["certificate1"],
-            "version": 0,
-        } in relation_3_databag
-        assert {
-            "certificate": "certificate2",
-            "ca": "certificate2",
-            "chain": ["certificate2"],
-            "version": 0,
-        } in relation_3_databag
+        assert set(json.loads(relation_3_unit_data["chain"])) == {"certificate1", "certificate2"}
         relation_4_unit_data = state_out.get_relation(relation_4.id).local_unit_data
-        relation_4_databag = json.loads(relation_4_unit_data["certificates"])
-        assert len(relation_4_databag) == 2
-        assert {
-            "certificate": "certificate1",
-            "ca": "certificate1",
-            "chain": ["certificate1"],
-            "version": 0,
-        } in relation_4_databag
-        assert {
-            "certificate": "certificate2",
-            "ca": "certificate2",
-            "chain": ["certificate2"],
-            "version": 0,
-        } in relation_4_databag
+        assert set(json.loads(relation_4_unit_data["chain"])) == {"certificate1", "certificate2"}
 
     def test_given_multiple_relations_when_remove_certificate_with_relation_id_v0_then_certificate_removed_from_specific_relation(
         self,
@@ -682,22 +553,10 @@ the databags except using the public methods in the provider library and use ver
             interface="certificate_transfer",
             remote_app_data={"version": "0"},
             local_unit_data={
-                "certificates": json.dumps(
-                    [
-                        {
-                            "certificate": "certificate1",
-                            "ca": "certificate1",
-                            "chain": ["certificate1"],
-                            "version": 0,
-                        },
-                        {
-                            "certificate": "certificate2",
-                            "ca": "certificate2",
-                            "chain": ["certificate2"],
-                            "version": 0,
-                        },
-                    ]
-                )
+                "certificate": json.dumps("certificate1"),
+                "ca": json.dumps("certificate1"),
+                "chain": json.dumps(["certificate1", "certificate2"]),
+                "version": json.dumps(0),
             },
         )
         state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])
@@ -724,14 +583,7 @@ the databags except using the public methods in the provider library and use ver
             "certificate2",
         }
         relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
-        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
-        assert len(relation_3_databag) == 1
-        assert {
-            "certificate": "certificate2",
-            "ca": "certificate2",
-            "chain": ["certificate2"],
-            "version": 0,
-        } in relation_3_databag
+        assert set(json.loads(relation_3_unit_data["chain"])) == {"certificate2"}
 
     def test_given_multiple_relations_when_remove_certificate_with_relation_id_no_version_then_certificate_removed_from_specific_relation(
         self,
@@ -752,22 +604,10 @@ the databags except using the public methods in the provider library and use ver
             endpoint="certificate_transfer",
             interface="certificate_transfer",
             local_unit_data={
-                "certificates": json.dumps(
-                    [
-                        {
-                            "certificate": "certificate1",
-                            "ca": "certificate1",
-                            "chain": ["certificate1"],
-                            "version": 0,
-                        },
-                        {
-                            "certificate": "certificate2",
-                            "ca": "certificate2",
-                            "chain": ["certificate2"],
-                            "version": 0,
-                        },
-                    ]
-                )
+                "certificate": json.dumps("certificate1"),
+                "ca": json.dumps("certificate1"),
+                "chain": json.dumps(["certificate1", "certificate2"]),
+                "version": json.dumps(0),
             },
         )
         state_in = scenario.State(leader=True, relations=[relation_1, relation_2, relation_3])
@@ -794,14 +634,7 @@ the databags except using the public methods in the provider library and use ver
             "certificate2",
         }
         relation_3_unit_data = state_out.get_relation(relation_3.id).local_unit_data
-        relation_3_databag = json.loads(relation_3_unit_data["certificates"])
-        assert len(relation_3_databag) == 1
-        assert {
-            "certificate": "certificate2",
-            "ca": "certificate2",
-            "chain": ["certificate2"],
-            "version": 0,
-        } in relation_3_databag
+        assert set(json.loads(relation_3_unit_data["chain"])) == {"certificate2"}
 
     def test_given_multiple_relations_when_remove_all_certificates_then_certificates_removed_from_all_relations(
         self,

--- a/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
+++ b/tests/unit/charms/certificate_transfer_interface/v1/test_certificate_transfer_requires_v1.py
@@ -150,16 +150,10 @@ class TestCertificateTransferRequiresV1:
             local_app_data={"version": "1"},
             remote_units_data={
                 0: {
-                    "certificates": json.dumps(
-                        [
-                            {
-                                "certificate": "cert1",
-                                "ca": "cert1",
-                                "chain": ["cert1"],
-                                "version": 0,
-                            }
-                        ]
-                    )
+                    "certificate": json.dumps("cert1"),
+                    "ca": json.dumps("cert1"),
+                    "chain": json.dumps(["cert1"]),
+                    "version": json.dumps(0),
                 }
             },
         )


### PR DESCRIPTION
# Description

The previous implementation did not work properly with a charm using the library v0. The reason was a misunderstanding that v0 of the interface does not send a list, but a single object.

This reworks the compatibility code to send the right format. Because we can support multiple certificates, they will be included in the chain.

This is manually tested in `manual-tls-certificates`, deployed with `traefik-k8s`, which uses library `v0`.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
